### PR TITLE
set_blob_metadata

### DIFF
--- a/lib/waz/blobs/blob_object.rb
+++ b/lib/waz/blobs/blob_object.rb
@@ -77,6 +77,12 @@ module WAZ
         raise WAZ::Blobs::InvalidOperation if self.snapshot_date
         self.class.service_instance.set_blob_properties(path, properties)
       end
+
+      # Stores blob metadata. User metadata must be prefixed with 'x-ms-meta-'. The advantage of this over put_properties
+      # is that it only affect user_metadata and doesn't overwrite any system values, like 'content_type'.
+      def put_metadata!(metadata = {})  
+        self.class.service_instance.set_blob_metadata(path, metadata)
+      end 
       
       # Removes the blob from the container.
       def destroy!

--- a/lib/waz/blobs/service.rb
+++ b/lib/waz/blobs/service.rb
@@ -103,6 +103,11 @@ module WAZ
         execute :put, path, { :comp => 'properties' }, properties.merge({:x_ms_version => "2009-09-19"})
       end
       
+      # Set user defined metadata - overwrites any previous metadata key:value pairs
+      def set_blob_metadata(path, metadata = {}) 
+        execute :put, path, { :comp => 'metadata' }, metadata.merge({:x_ms_version => "2009-09-19"})
+      end 
+
       # Copies a blob within the same account (not necessarily to the same container)
       def copy_blob(source_path, dest_path)
         execute :put, dest_path, nil, { :x_ms_version => "2009-09-19", :x_ms_copy_source => canonicalize_message(source_path) }


### PR DESCRIPTION
Hi Jonny, 

please include this minor fix for blob metadata. There was no implementation for the 'set blob_metadata' call. At first sight this might seem a non problem since there's a 'set_blob_properties' call. However, if you use this and don't set 'content_type' on the blob then the content_type gets removed alltogether. 

This then causes things to blow up since you have in '/lib/waz/blobs/blob_object.rb' line 47 you have:
 47         raise WAZ::Storage::InvalidOption, :content_type unless options.keys.include?(:content_type) and !options[:content_type].empty?

This in itself is another issue, i mean, is it really dictated by the azure api that content_type is an absolute requirement (e.g. see http://msdn.microsoft.com/en-us/library/dd179451.aspx - i read that as content_type being optional).

Anyway, if you include the 'set_blob_metadata' calls then only the user_metadata gets overwritten (and things like content_type aren't touched at all), 

thanks! 

marios
