### PR TITLE
Upload from stream, plus XML/URI escaping in various places, and a few other minor fixes

### DIFF
--- a/lib/waz/blobs/service.rb
+++ b/lib/waz/blobs/service.rb
@@ -83,7 +83,19 @@ module WAZ
         default_headers = {"Content-Type" => content_type, :x_ms_version => "2009-09-19", :x_ms_blob_type => "BlockBlob"}
         execute :put, path, nil, metadata.merge(default_headers), payload
       end
-      
+
+      # Commits a list of blocks to the given blob.
+      #
+      # blockids is a list of valid, already-uploaded block IDs (base64-encoded)
+      #
+      # content_type is required by the blobs api, but on this method is defaulted to "application/octect-stream"
+      #
+      # metadata is a hash that stores all the properties that you want to add to the blob when creating it.
+      def put_block_list(path, blockids, content_type = "application/octet-stream", metadata = {})
+        default_headers = {"Content-Type" => content_type, :x_ms_version => "2009-09-19"}
+        execute :put, path, { :comp => 'blocklist' }, metadata.merge(default_headers), '<?xml version="1.0" encoding="utf-8"?><BlockList>' + blockids.map {|id| "<Latest>#{id.rstrip}</Latest>"}.join + '</BlockList>'
+      end
+
       # Retrieves a blob (content + headers) from the current path.
       def get_blob(path, options = {})
         execute :get, path, options, {:x_ms_version => "2009-09-19"}

--- a/lib/waz/storage/core_service.rb
+++ b/lib/waz/storage/core_service.rb
@@ -58,7 +58,7 @@ module WAZ
       # Creates a canonical representation of the message by combining account_name/resource_path.
       def canonicalize_message(url)
         uri_component = url.gsub(/https?:\/\/[^\/]+\//i, '').gsub(/\?.*/i, '')
-        comp_component = url.scan(/(comp=[^&]+)/i).first()
+        comp_component = url.scan(/comp=[^&]+/i).first()
         uri_component << "?#{comp_component}" if comp_component
         canonicalized_message = "/#{self.account_name}/#{uri_component}"
         return canonicalized_message
@@ -104,7 +104,7 @@ module WAZ
       def canonicalize_message20090919(url)
         uri_component = url.gsub(/https?:\/\/[^\/]+\//i, '').gsub(/\?.*/i, '')
         query_component = (url.scan(/\?(.*)/i).first() or []).first()
-        query_component = query_component.split('&').sort{|a, b| a <=> b}.map{ |p| p.split('=').join(':') }.join("\n") if query_component
+        query_component = query_component.split('&').sort{|a, b| a <=> b}.map{ |p| CGI::unescape(p.split('=').join(':')) }.join("\n") if query_component
         canonicalized_message = "/#{self.account_name}/#{uri_component}"
         canonicalized_message << "\n#{query_component}" if query_component
         return canonicalized_message

--- a/lib/waz/tables/service.rb
+++ b/lib/waz/tables/service.rb
@@ -139,17 +139,17 @@ module WAZ
         def generate_payload(table_name, entity)
           payload = "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" \
                      "<entry xmlns:d=\"#{DATASERVICES_NAMESPACE}\" xmlns:m=\"#{DATASERVICES_METADATA_NAMESPACE}\" xmlns=\"http://www.w3.org/2005/Atom\">" \
-                     "<id>#{generate_request_uri "#{table_name}"}(PartitionKey='#{entity[:partition_key]}',RowKey='#{entity[:row_key]}')</id>" \
-                     "<title /><updated>#{Time.now.utc.iso8601}</updated><author><name /></author><link rel=\"edit\" title=\"#{table_name}\" href=\"#{table_name}(PartitionKey='#{entity[:partition_key]}',RowKey='#{entity[:row_key]}')\" />" \
+                     "<id>#{generate_request_uri "#{table_name}"}(PartitionKey='#{REXML::Text.new(entity[:partition_key], false, nil, false).to_s}',RowKey='#{REXML::Text.new(entity[:row_key], false, nil, false).to_s}')</id>" \
+                     "<title /><updated>#{Time.now.utc.iso8601}</updated><author><name /></author><link rel=\"edit\" title=\"#{table_name}\" href=\"#{table_name}(PartitionKey='#{REXML::Text.new(entity[:partition_key], false, nil, false).to_s}',RowKey='#{REXML::Text.new(entity[:row_key], false, nil, false).to_s}')\" />" \
                      "<content type=\"application/xml\"><m:properties>"
 
           entity.sort_by { |k| k.to_s }.each do |k,v| 
             value, type = EdmTypeHelper.parse_to(v)[0].to_s, EdmTypeHelper.parse_to(v)[1].to_s
-            payload << (!v.nil? ? "<d:#{k.to_s} m:type=\"#{k.edm_type || type}\">#{value}</d:#{k.to_s}>" : "<d:#{k.to_s} m:type=\"#{k.edm_type || type}\" m:null=\"true\" />") unless k.eql?(:partition_key) or k.eql?(:row_key) 
+            payload << (!v.nil? ? "<d:#{k.to_s} m:type=\"#{k.edm_type || type}\">#{REXML::Text.new(value, false, nil, false).to_s}</d:#{k.to_s}>" : "<d:#{k.to_s} m:type=\"#{k.edm_type || type}\" m:null=\"true\" />") unless k.eql?(:partition_key) or k.eql?(:row_key) 
           end  
 
-          payload << "<d:PartitionKey>#{entity[:partition_key]}</d:PartitionKey>" \
-                     "<d:RowKey>#{entity[:row_key]}</d:RowKey>" \
+          payload << "<d:PartitionKey>#{REXML::Text.new(entity[:partition_key], false, nil, false).to_s}</d:PartitionKey>" \
+                     "<d:RowKey>#{REXML::Text.new(entity[:row_key], false, nil, false).to_s}</d:RowKey>" \
                      "</m:properties></content></entry>"
           return payload
         end

--- a/rakefile
+++ b/rakefile
@@ -44,7 +44,7 @@ end
 namespace :docs do
   Rake::RDocTask.new do |t|
   	t.rdoc_dir = 'rdoc'
-  	t.title    = "Windows Azure Storage library — simple gem for accessing WAZ‘s Storage REST API"
+  	t.title    = "Windows Azure Storage library - simple gem for accessing WAZ's Storage REST API"
   	t.options << '--line-numbers' << '--inline-source' << '-A cattr_accessor=object'
   	t.options << '--charset' << 'utf-8'
   	t.rdoc_files.include('README.rdoc')

--- a/tests/waz/blobs/service_test.rb
+++ b/tests/waz/blobs/service_test.rb
@@ -11,18 +11,18 @@ describe "blobs service behavior" do
     service.expects(:generate_request).with(:put, "mock-uri", {:x_ms_version => '2009-09-19'}, nil).returns(RestClient::Request.new(:method => :put, :url => "http://localhost"))
     service.create_container('mock-container')
   end
-   
+
   it "should get container properties" do
     service = WAZ::Blobs::Service.new(:account_name => "mock-account", :access_key => "mock-key", :type_of_service => "queue", :use_ssl => true, :base_url => "localhost")
     mock_response = mock()
-    mock_response.stubs(:headers).returns(RestClient::AbstractResponse.beautify_headers({"x-ms-meta-Name" => "customName"}))
+    mock_response.stubs(:headers).returns(RestClient::AbstractResponse.beautify_headers({"x-ms-meta-Name" => ["customName"]}))
     RestClient::Request.any_instance.expects(:execute).returns(mock_response)
     service.expects(:generate_request_uri).with("mock-container", {:restype => 'container'}).returns("mock-uri")
     service.expects(:generate_request).with(:get, "mock-uri", {:x_ms_version => '2009-09-19'}, nil).returns(RestClient::Request.new(:method => :get, :url => "http://localhost"))
     properties = service.get_container_properties('mock-container')
     properties[:x_ms_meta_name].should == "customName"
   end
-  
+
   it "should set container properties" do
     service = WAZ::Blobs::Service.new(:account_name => "mock-account", :access_key => "mock-key", :type_of_service => "queue", :use_ssl => true, :base_url => "localhost")
     RestClient::Request.any_instance.expects(:execute)
@@ -34,13 +34,13 @@ describe "blobs service behavior" do
   it "should get container acl" do
     service = WAZ::Blobs::Service.new(:account_name => "mock-account", :access_key => "mock-key", :type_of_service => "queue", :use_ssl => true, :base_url => "localhost")
     mock_response = mock()
-    mock_response.stubs(:headers).returns(RestClient::AbstractResponse.beautify_headers({"x-ms-prop-publicaccess" => true.to_s}))
+    mock_response.stubs(:headers).returns(RestClient::AbstractResponse.beautify_headers({"x-ms-prop-publicaccess" => [true.to_s]}))
     RestClient::Request.any_instance.expects(:execute).returns(mock_response)
     service.expects(:generate_request_uri).with("mock-container", {:restype => 'container', :comp => 'acl'}).returns("mock-uri")
     service.expects(:generate_request).with(:get, "mock-uri", {:x_ms_version => '2009-09-19'}, nil).returns(RestClient::Request.new(:method => :get, :url => "http://localhost"))
     service.get_container_acl('mock-container').should == true
   end
-  
+
   it "should set container acl" do
     service = WAZ::Blobs::Service.new(:account_name => "mock-account", :access_key => "mock-key", :type_of_service => "queue", :use_ssl => true, :base_url => "localhost")
     RestClient::Request.any_instance.expects(:execute)
@@ -48,7 +48,7 @@ describe "blobs service behavior" do
     service.expects(:generate_request).with(:put, "mock-uri", {:x_ms_version => '2009-09-19', :x_ms_prop_publicaccess => "false"}, nil).returns(RestClient::Request.new(:method => :put, :url => "http://localhost"))
     properties = service.set_container_acl('mock-container', false)
   end
-  
+
   it "should list containers" do
     response = <<-eos
                 <?xml version="1.0" encoding="utf-8"?>
@@ -75,7 +75,7 @@ describe "blobs service behavior" do
     containers[0][:name].should == "mycontainer"
     containers[1][:name].should == "othercontainer"    
   end
-  
+
   it "should delete container" do
     service = WAZ::Blobs::Service.new(:account_name => "mock-account", :access_key => "mock-key", :type_of_service => "queue", :use_ssl => true, :base_url => "localhost")
     RestClient::Request.any_instance.expects(:execute)
@@ -83,7 +83,7 @@ describe "blobs service behavior" do
     service.expects(:generate_request).with(:delete, "mock-uri", {:x_ms_version => '2009-09-19'}, nil).returns(RestClient::Request.new(:method => :put, :url => "http://localhost"))
     service.delete_container('mock-container')
   end
-  
+
   it "should list blobs" do
     response = <<-eos
                 <?xml version="1.0" encoding="utf-8"?>
@@ -124,7 +124,7 @@ describe "blobs service behavior" do
     blobs[0][:content_type].should == "text/xml"
     blobs[1][:content_type].should == "application/x-stream"
   end
-  
+
   it "should put blob" do
     service = WAZ::Blobs::Service.new(:account_name => "mock-account", :access_key => "mock-key", :type_of_service => "queue", :use_ssl => true, :base_url => "localhost")
     RestClient::Request.any_instance.expects(:execute).returns(nil)
@@ -132,7 +132,7 @@ describe "blobs service behavior" do
     service.expects(:generate_request).with(:put, "mock-uri", {'Content-Type' => 'application/octet-stream', :x_ms_version => "2009-09-19", :x_ms_blob_type => "BlockBlob"}, "payload").returns(RestClient::Request.new(:method => :put, :url => "http://localhost"))
     service.put_blob("container/blob", "payload")
   end
-  
+
   it "should get blob" do
     service = WAZ::Blobs::Service.new(:account_name => "mock-account", :access_key => "mock-key", :type_of_service => "queue", :use_ssl => true, :base_url => "localhost")
     RestClient::Request.any_instance.expects(:execute).returns("payload")
@@ -140,7 +140,7 @@ describe "blobs service behavior" do
     service.expects(:generate_request).with(:get, "mock-uri", {:x_ms_version => "2009-09-19"}, nil).returns(RestClient::Request.new(:method => :get, :url => "http://localhost"))
     service.get_blob("container/blob").should == "payload"
   end
-  
+
   it "should delete blob" do
     service = WAZ::Blobs::Service.new(:account_name => "mock-account", :access_key => "mock-key", :type_of_service => "queue", :use_ssl => true, :base_url => "localhost")
     RestClient::Request.any_instance.expects(:execute).returns(nil)
@@ -148,17 +148,17 @@ describe "blobs service behavior" do
     service.expects(:generate_request).with(:delete, "mock-uri", {:x_ms_version => "2009-09-19"}, nil).returns(RestClient::Request.new(:method => :put, :url => "http://localhost"))
     service.delete_blob("container/blob")
   end
-  
+
   it "should get blob properties" do
     service = WAZ::Blobs::Service.new(:account_name => "mock-account", :access_key => "mock-key", :type_of_service => "queue", :use_ssl => true, :base_url => "localhost")
     response = mock()
-    response.stubs(:headers).returns(RestClient::AbstractResponse.beautify_headers({"x-ms-meta-Name" => "customName"}))
+    response.stubs(:headers).returns(RestClient::AbstractResponse.beautify_headers({"x-ms-meta-Name" => ["customName"]}))
     RestClient::Request.any_instance.expects(:execute).returns(response)
     service.expects(:generate_request_uri).with("container/blob", {}).returns("mock-uri")
     service.expects(:generate_request).with(:head, "mock-uri", {:x_ms_version => '2009-09-19'}, nil).returns(RestClient::Request.new(:method => :get, :url => "http://localhost"))
     service.get_blob_properties("container/blob").should == response.headers
   end
-  
+
   it "should set blob properties" do
     service = WAZ::Blobs::Service.new(:account_name => "mock-account", :access_key => "mock-key", :type_of_service => "queue", :use_ssl => true, :base_url => "localhost")
     RestClient::Request.any_instance.expects(:execute).returns(nil)
@@ -166,7 +166,7 @@ describe "blobs service behavior" do
     service.expects(:generate_request).with(:put, "mock-uri", {:x_ms_version => '2009-09-19', :x_ms_meta_Name => "johnny"}, nil).returns(RestClient::Request.new(:method => :get, :url => "http://localhost"))
     service.set_blob_properties("container/blob", {:x_ms_meta_Name => "johnny"})
   end
-  
+
   it "should copy blob" do
     service = WAZ::Blobs::Service.new(:account_name => "mock-account", :access_key => "mock-key", :type_of_service => "queue", :use_ssl => true, :base_url => "localhost")
     RestClient::Request.any_instance.expects(:execute).returns(nil)
@@ -174,15 +174,23 @@ describe "blobs service behavior" do
     service.expects(:generate_request).with(:put, "mock-uri", {:x_ms_version => "2009-09-19", :x_ms_copy_source => "/mock-account/container/blob"}, nil).returns(RestClient::Request.new(:method => :get, :url => "http://localhost"))
     service.copy_blob("container/blob", "container/blob-copy")
   end
-  
+
   it "should put block" do
     service = WAZ::Blobs::Service.new(:account_name => "mock-account", :access_key => "mock-key", :type_of_service => "queue", :use_ssl => true, :base_url => "localhost")
     RestClient::Request.any_instance.expects(:execute).returns(nil)
     service.expects(:generate_request_uri).with("container/blob", { :blockid => 'block_id', :comp => 'block'}).returns("mock-uri")
     service.expects(:generate_request).with(:put, "mock-uri", {'Content-Type' => 'application/octet-stream'}, "payload").returns(RestClient::Request.new(:method => :get, :url => "http://localhost"))
     service.put_block("container/blob", "block_id", "payload")
-  end 
-  
+  end
+
+  it "should put block list" do
+    service = WAZ::Blobs::Service.new(:account_name => "mock-account", :access_key => "mock-key", :type_of_service => "queue", :use_ssl => true, :base_url => "localhost")
+    RestClient::Request.any_instance.expects(:execute).returns(nil)
+    service.expects(:generate_request_uri).with("container/blob", { :comp => 'blocklist'}).returns("mock-uri")
+    service.expects(:generate_request).with(:put, "mock-uri", {'Content-Type' => 'text/plain', :x_ms_version => '2009-09-19'}, '<?xml version="1.0" encoding="utf-8"?><BlockList><Latest>AAAAAA==</Latest><Latest>AQAAAA==</Latest></BlockList>').returns(RestClient::Request.new(:method => :get, :url => "http://localhost"))
+    service.put_block_list("container/blob", ["AAAAAA==", "AQAAAA=="], "text/plain")
+  end
+
   it "should list blocks" do
     response = <<-eos
                 <?xml version="1.0" encoding="utf-8"?>
@@ -217,7 +225,7 @@ describe "blobs service behavior" do
     blocks.last[:size].should == "402848"
     blocks.last[:committed].should == false
   end
-  
+
   it "should list with additional parameters" do
     response = <<-eos
                 <?xml version="1.0" encoding="utf-8"?>
@@ -252,13 +260,13 @@ describe "blobs service behavior" do
     blocks.last[:size].should == "402848"
     blocks.last[:committed].should == false
   end
-  
+
   it "should throw when block list type is nil or doesn't fall into the valid values" do
     service = WAZ::Blobs::Service.new(:account_name => "mock-account", :access_key => "mock-key", :type_of_service => "queue", :use_ssl => true, :base_url => "localhost")
     lambda { service.list_blocks('container/blob', 'whatever') }.should raise_error(WAZ::Storage::InvalidParameterValue)
     lambda { service.list_blocks('container/blob', nil) }.should raise_error(WAZ::Storage::InvalidParameterValue)    
   end
-  
+
   it "should take blob snapshots" do
     service = WAZ::Blobs::Service.new(:account_name => "mock-account", :access_key => "mock-key", :type_of_service => "queue", :use_ssl => true, :base_url => "localhost")
     


### PR DESCRIPTION
- Add upload method to container
- Add put_block_list to support upload
- Fix message canonicalization of ?comp= parameters for versions prior to 2009-09-19 (seems put_block was broken)
- Unescape query string parameters when constructing signatures (needed for put_block, since some base64-encoded names include non-URI-friendly characters)
- XML-escape property values for table entities (needed to insert things containing &, <, etc.)
- Remove Unicode characters from rakefile (was breaking something on Windows)
- Add tests for put_block_list and upload
- Fix tests for content type (typo, = instead of .should ==)
- Fix tests using RestClient.beautify_headers (expects an array, not a scalar)
