### PR TITLE
waz-storage fails to treat container publicity

### DIFF
--- a/lib/waz/blobs/container.rb
+++ b/lib/waz/blobs/container.rb
@@ -97,14 +97,22 @@ module WAZ
       
       # Retuns a value indicating whether the container is public accessible (i.e. from a Web Browser) or not.
       def public_access?
+        !self.class.service_instance.get_container_acl(self.name).nil?
+      end
+      
+      # Sets a value indicating whether the container is public accessible (i.e. from a Web Browser) or not.  
+      def public_access=(value)
+        self.class.service_instance.set_container_acl(self.name, value ? 'container' : nil)
+      end
+      
+      def publicity
         self.class.service_instance.get_container_acl(self.name)
       end
-      
-      # Sets a value indicating whether the container is public accessible (i.e. from a Web Browser) or not.      
-      def public_access=(value)
+
+      def publicity=(value)
         self.class.service_instance.set_container_acl(self.name, value)
       end
-      
+
       # Returns a list of blobs (WAZ::Blobs::BlobObject) contained on the current container.
       def blobs
         self.class.service_instance.list_blobs(name).map { |blob| WAZ::Blobs::BlobObject.new(blob) }

--- a/lib/waz/blobs/container.rb
+++ b/lib/waz/blobs/container.rb
@@ -97,22 +97,14 @@ module WAZ
       
       # Retuns a value indicating whether the container is public accessible (i.e. from a Web Browser) or not.
       def public_access?
-        !self.class.service_instance.get_container_acl(self.name).nil?
+        self.class.service_instance.get_container_acl(self.name)
       end
       
       # Sets a value indicating whether the container is public accessible (i.e. from a Web Browser) or not.  
       def public_access=(value)
-        self.class.service_instance.set_container_acl(self.name, value ? 'container' : nil)
-      end
-      
-      def publicity
-        self.class.service_instance.get_container_acl(self.name)
-      end
-
-      def publicity=(value)
         self.class.service_instance.set_container_acl(self.name, value)
       end
-
+      
       # Returns a list of blobs (WAZ::Blobs::BlobObject) contained on the current container.
       def blobs
         self.class.service_instance.list_blobs(name).map { |blob| WAZ::Blobs::BlobObject.new(blob) }
@@ -158,6 +150,11 @@ module WAZ
           return nil
         end
       end
+    end
+    class BlobSecurity
+      Container = 'container'
+      Blob = 'blob'
+      Private = ''
     end
   end
 end

--- a/lib/waz/blobs/service.rb
+++ b/lib/waz/blobs/service.rb
@@ -36,9 +36,9 @@ module WAZ
       # accessible or not.
       #
       # Default is _false_
-      def set_container_acl(container_name, public_available = false)
+      def set_container_acl(container_name, public_available = WAZ::Blobs::BlobSecurity::Private)
         publicity = {:x_ms_version => '2009-09-19' }
-        publicity[:x_ms_blob_public_access] = public_available unless public_available.nil?
+        publicity[:x_ms_blob_public_access] = public_available unless public_available == WAZ::Blobs::BlobSecurity::Private
         execute :put, container_name, { :restype => 'container', :comp => 'acl' }, publicity
       end
 

--- a/lib/waz/blobs/service.rb
+++ b/lib/waz/blobs/service.rb
@@ -28,7 +28,7 @@ module WAZ
       # accessible or not.
       def get_container_acl(container_name)
         headers = execute(:get, container_name, { :restype => 'container', :comp => 'acl' }, {:x_ms_version => '2009-09-19'}).headers
-        headers[:x_ms_prop_publicaccess].downcase == true.to_s
+        headers[:x_ms_blob_public_access]
       end
 
       # Sets the value of the :x_ms_prop_publicaccess header from the
@@ -37,7 +37,9 @@ module WAZ
       #
       # Default is _false_
       def set_container_acl(container_name, public_available = false)
-        execute :put, container_name, { :restype => 'container', :comp => 'acl' }, { :x_ms_prop_publicaccess => public_available.to_s, :x_ms_version => '2009-09-19' }
+        publicity = {:x_ms_version => '2009-09-19' }
+        publicity[:x_ms_blob_public_access] = public_available unless public_available.nil?
+        execute :put, container_name, { :restype => 'container', :comp => 'acl' }, publicity
       end
 
       # Lists all the containers existing on the current storage account.


### PR DESCRIPTION
I have fixed the problem in the subject. I sent you an email for details.

I changed the field name in Service#get/set_container_acl.
The field does not accept true/false, these methods should use the value in string directly.
Given nil as value, set_container_acl generates a request without publicity field to make the container private.

For backward compatibility, Container#public_access? and public_access still work with boolean value,
