### PR TITLE
Here's what fixes the waz-storage container.upload method. I url-encoded the path still, as when I tested it with filenames with spaces not doing that caused errors.

### DIFF
--- a/lib/waz/storage/core_service.rb
+++ b/lib/waz/storage/core_service.rb
@@ -113,8 +113,8 @@ module WAZ
       # Generates a Windows Azure Storage call, it internally calls url generation method
       # and the request generation message.
       def execute(verb, path, query = {}, headers = {}, payload = nil)
-        url = generate_request_uri(path, query)
-        request = generate_request(verb, URI.encode(url), headers, payload)
+		url = generate_request_uri(URI.encode(path), query)
+        request = generate_request(verb, url, headers, payload)
         request.execute()
       end
     end


### PR DESCRIPTION
All of the other query parameters are already URI.encoded anyways. Prior to this, the library was double URI.encoding characters such as '%'.
