### PR TITLE
Add statistics

### DIFF
--- a/lib/waz/blobs/container.rb
+++ b/lib/waz/blobs/container.rb
@@ -83,7 +83,18 @@ module WAZ
       def metadata
         self.class.service_instance.get_container_properties(self.name)
       end
-      
+
+      # Returns statistics of the container.
+      #
+      # @param [Hash] options
+      # @option options [String] :maxresults max blobs(5,000 at most)
+      # @option options [String] :marker marker of a page("2!80!MDAwMDE0***********--")
+      #
+      # @return [Hash] {:size => Integer, :files => Integer, :marker => String}
+      def statistics(options)
+        self.class.service_instance.statistics(self.name, options)
+      end
+
       # Adds metadata for the container.Those properties are sent as HTTP Headers it's really important that you name your custom 
       # properties with the <em>x-ms-meta</em> prefix, if not the won't be persisted by the Windows Azure Blob Storage API.
       def put_properties!(properties = {})

--- a/lib/waz/blobs/service.rb
+++ b/lib/waz/blobs/service.rb
@@ -96,7 +96,7 @@ module WAZ
         end
 
         next_marker = REXML::XPath.first(doc, '//NextMarker')
-        {:size => size, :files => files, :marker => next_marker.text.length == 0 ? nil : next_marker.text}
+        {:size => size, :files => files, :next_marker => next_marker.text}
       end
 
       # Stores a blob on the given container.

--- a/lib/waz/blobs/service.rb
+++ b/lib/waz/blobs/service.rb
@@ -74,6 +74,31 @@ module WAZ
         return containers
       end
 
+      # Returns statistics of the given container.
+      #
+      # @param [String] container_name
+      # @param [Hash] add_options
+      # @option add_options [String] :maxresults max blobs(5,000 at most)
+      # @option add_options [String] :marker marker of a page("2!80!MDAwMDE0***********--")
+      #
+      # @return [Hash] {:size => Integer, :files => Integer, :marker => String}
+      def statistics(container_name, add_options={})
+        options = { :restype => 'container', :comp => 'list'}
+        options.merge!(add_options)
+
+        content = execute(:get, container_name, options, {:x_ms_version => '2011-08-18'})
+        doc = REXML::Document.new(content)
+        size = 0
+        files = 0
+        REXML::XPath.each(doc, '//Blob/') do |item|
+          size = size + REXML::XPath.first(item.elements["Properties"], "Content-Length").text.to_i
+          files = files + 1
+        end
+
+        next_marker = REXML::XPath.first(doc, '//NextMarker')
+        {:size => size, :files => files, :marker => next_marker.text.length == 0 ? nil : next_marker.text}
+      end
+
       # Stores a blob on the given container.
       # 
       # Remarks path and payload are just text.

--- a/spec/waz/blobs/container_spec.rb
+++ b/spec/waz/blobs/container_spec.rb
@@ -73,6 +73,19 @@ describe "Windows Azure Containers interface API" do
     container_blobs.first().name = expected_blobs[0][:name]
     container_blobs[1].name = expected_blobs[1][:name]
   end
+
+  it "should be able to return statistics of the container" do
+    options = {:maxresults => 100, :marker => "marker"}
+    expected_values = {:size => 200, :files => 100, :marker => "next-marker"}
+    WAZ::Storage::Base.stubs(:default_connection).returns({:account_name => "my_account", :access_key => "key"})
+    WAZ::Blobs::Service.any_instance.expects(:get_container_properties).with("container-name").returns({:x_ms_meta_name => "container-name"})
+    WAZ::Blobs::Service.any_instance.expects(:statistics).with("container-name", options).returns(expected_values)
+    container = WAZ::Blobs::Container.find("container-name")
+    statistics = container.statistics(options)
+    statistics[:size].should == 200
+    statistics[:files].should == 100
+    statistics[:marker].should == "next-marker"
+  end
   
   it "should destroy container" do
     WAZ::Storage::Base.stubs(:default_connection).returns({:account_name => "my_account", :access_key => "key"})

--- a/spec/waz/blobs/container_spec.rb
+++ b/spec/waz/blobs/container_spec.rb
@@ -76,7 +76,7 @@ describe "Windows Azure Containers interface API" do
 
   it "should be able to return statistics of the container" do
     options = {:maxresults => 100, :marker => "marker"}
-    expected_values = {:size => 200, :files => 100, :marker => "next-marker"}
+    expected_values = {:size => 200, :files => 100, :next_marker => "next-marker"}
     WAZ::Storage::Base.stubs(:default_connection).returns({:account_name => "my_account", :access_key => "key"})
     WAZ::Blobs::Service.any_instance.expects(:get_container_properties).with("container-name").returns({:x_ms_meta_name => "container-name"})
     WAZ::Blobs::Service.any_instance.expects(:statistics).with("container-name", options).returns(expected_values)
@@ -84,7 +84,7 @@ describe "Windows Azure Containers interface API" do
     statistics = container.statistics(options)
     statistics[:size].should == 200
     statistics[:files].should == 100
-    statistics[:marker].should == "next-marker"
+    statistics[:next_marker].should == "next-marker"
   end
   
   it "should destroy container" do

--- a/spec/waz/blobs/service_spec.rb
+++ b/spec/waz/blobs/service_spec.rb
@@ -176,7 +176,7 @@ describe "blobs service behavior" do
     statistics = service.statistics("container", add_options)
     statistics[:size].should == 13
     statistics[:files].should == 2
-    statistics[:marker].should == 'test-marker'
+    statistics[:next_marker].should == 'test-marker'
   end
 
   it "should put blob" do

--- a/spec/waz/blobs/service_spec.rb
+++ b/spec/waz/blobs/service_spec.rb
@@ -125,6 +125,60 @@ describe "blobs service behavior" do
     blobs[1][:content_type].should == "application/x-stream"
   end
 
+  it "should statistics" do
+    response = <<-eos
+                <?xml version='1.0' encoding='UTF-8'?>
+                <EnumerationResults ContainerName='http://myaccount.blob.core.windows.net/hiro-test'>
+                  <Blobs>
+                    <Blob>
+                      <Name>000/000000.txt</Name>
+                      <Url>http://myaccount.blob.core.windows.net/hiro-test/000/000000.txt</Url>
+                      <Properties>
+                        <Last-Modified>Mon, 07 Jan 2013 05:31:13 GMT</Last-Modified>
+                        <Etag>0x8CFBAAF57E5A6C5</Etag>
+                        <Content-Length>1</Content-Length>
+                        <Content-Type>application/octet-stream</Content-Type>
+                        <Content-Encoding/>
+                        <Content-Language/>
+                        <Content-MD5/>
+                        <Cache-Control/>
+                        <BlobType>BlockBlob</BlobType>
+                        <LeaseStatus>unlocked</LeaseStatus>
+                      </Properties>
+                    </Blob>
+                    <Blob>
+                      <Name>000/000001.txt</Name>
+                      <Url>http://myaccount.blob.core.windows.net/hiro-test/000/000001.txt</Url>
+                      <Properties>
+                        <Last-Modified>Mon, 07 Jan 2013 05:31:15 GMT</Last-Modified>
+                        <Etag>0x8CFBAAF58DF9D8B</Etag>
+                        <Content-Length>12</Content-Length>
+                        <Content-Type>application/octet-stream</Content-Type>
+                        <Content-Encoding/>
+                        <Content-Language/>
+                        <Content-MD5/>
+                        <Cache-Control/>
+                        <BlobType>BlockBlob</BlobType>
+                        <LeaseStatus>unlocked</LeaseStatus>
+                      </Properties>
+                    </Blob>
+                  </Blobs>
+                  <NextMarker>test-marker</NextMarker>
+                </EnumerationResults>
+    eos
+    options = {:restype => 'container', :comp => 'list'}
+    add_options = {:maxresults => 1000}
+
+    service = WAZ::Blobs::Service.new(:account_name => "mock-account", :access_key => "mock-key", :type_of_service => "queue", :use_ssl => true, :base_url => "localhost")
+    RestClient::Request.any_instance.expects(:execute).returns(response)
+    service.expects(:generate_request_uri).with("container", options.merge(add_options)).returns("mock-uri")
+    service.expects(:generate_request).with(:get, "mock-uri", {:x_ms_version => '2011-08-18'}, nil).returns(RestClient::Request.new(:method => :get, :url => "http://localhost"))
+    statistics = service.statistics("container", add_options)
+    statistics[:size].should == 13
+    statistics[:files].should == 2
+    statistics[:marker].should == 'test-marker'
+  end
+
   it "should put blob" do
     service = WAZ::Blobs::Service.new(:account_name => "mock-account", :access_key => "mock-key", :type_of_service => "queue", :use_ssl => true, :base_url => "localhost")
     RestClient::Request.any_instance.expects(:execute).returns(nil)


### PR DESCRIPTION
Hello.

I couldn't get over 5,000 blobs using this gem.

Because List Blobs API is limited to 5,000 items.

http://msdn.microsoft.com/en-us/library/windowsazure/dd135734.aspx

To get over 5,000 blobs requires 'marker' option which is returned by List Blobs API. 

I only need size of blobs within a container for now,
so I add 'WAZ::Blobs::Container#statistics' and 'WAZ::Blobs::Service#statistics'.
which sums size of blobs within a container partially.

Please let this branch pull into your repository or fix this issue in other way.

Best Regards,
