### PR TITLE
Change URI.encode to CGI.escape

### DIFF
--- a/lib/waz/storage/core_service.rb
+++ b/lib/waz/storage/core_service.rb
@@ -113,7 +113,8 @@ module WAZ
       # Generates a Windows Azure Storage call, it internally calls url generation method
       # and the request generation message.
       def execute(verb, path, query = {}, headers = {}, payload = nil)
-		url = generate_request_uri(URI.encode(path), query)
+        escaped_path = path.split("/").map{ | part | CGI.escape(part) }.join("/")
+        url = generate_request_uri(escaped_path, query)
         request = generate_request(verb, url, headers, payload)
         request.execute()
       end


### PR DESCRIPTION
Hello, johnnyhalife!

I could not upload some files which include "[" or "]" in their names.

ex)
[en]English.txt
[ja]日本語.txt

This happens by using "URI.encode" at "WAZ::Storage::SharedKeyCoreService#execute".
I change this using CGI.escape and it works well.

Could you merge this pull request, please?

Cheers!
