### PR TITLE
Allow '$root'  as valid container name 

### DIFF
--- a/lib/waz/blobs/container.rb
+++ b/lib/waz/blobs/container.rb
@@ -41,7 +41,7 @@ module WAZ
       class << self 
         # Creates a new container with the given name.
         def create(name)
-          raise WAZ::Storage::InvalidParameterValue, {:name => "name", :values => ["lower letters, numbers or - (hypen), and must not start or end with - (hyphen)"]} unless WAZ::Storage::ValidationRules.valid_name?(name)
+          raise WAZ::Storage::InvalidParameterValue, {:name => "name", :values => ["lower letters, numbers or - (hypen), and must not start or end with - (hyphen)"]} unless WAZ::Storage::ValidationRules.valid_container_name?(name)
           service_instance.create_container(name)
           return Container.new(:name => name)
         end

--- a/lib/waz/queues/queue.rb
+++ b/lib/waz/queues/queue.rb
@@ -55,7 +55,7 @@ module WAZ
         # metadata to be stored on the queue. (Remember that metadata on the storage account must start with 
         # :x_ms_metadata_{yourCustomPropertyName}, if not it will not be persisted).
         def create(queue_name, metadata = {})
-          raise WAZ::Storage::InvalidParameterValue, {:name => "name", :values => ["lower letters, numbers or - (hypen), and must not start or end with - (hyphen)"]} unless WAZ::Storage::ValidationRules.valid_name?(queue_name)
+          raise WAZ::Storage::InvalidParameterValue, {:name => "name", :values => ["lower letters, numbers or - (hypen), and must not start or end with - (hyphen)"]} unless WAZ::Storage::ValidationRules.valid_queue_name?(queue_name)
           service_instance.create_queue(queue_name, metadata)
           WAZ::Queues::Queue.new(:name => queue_name, :url => service_instance.generate_request_uri(queue_name))
         end

--- a/lib/waz/storage/validation_rules.rb
+++ b/lib/waz/storage/validation_rules.rb
@@ -2,13 +2,24 @@ module WAZ
   module Storage
     class ValidationRules
       class << self
-        # Validates that the Container/Queue name given matches with the requirements of Windows Azure. 
+        # Validates that the Container name given matches with the requirements of Windows Azure. 
         #
-        # -Container/Queue names must start with a letter or number, and can contain only letters, numbers, and the dash (-) character.
+        # -Container names must start with a letter or number, and can contain only letters, numbers, and the dash (-) character.
         # -Every dash (-) character must be immediately preceded and followed by a letter or number.
         # -All letters in a container name must be lowercase.
-        # -Container/Queue names must be from 3 through 63 characters long.
-        def valid_name?(name)
+        # -Container names must be from 3 through 63 characters long.
+        # -An exception to the naming rules is made for the root container which may be addressed with the name "$root"
+        def valid_container_name?(name)
+          (name =~ /^[a-z0-9][a-z0-9\-]{1,}[^-]$/ && name.length < 64) || (name == "$root")
+        end
+        
+        # Validates that the Queue name given matches with the requirements of Windows Azure. 
+        #
+        # -Queue names must start with a letter or number, and can contain only letters, numbers, and the dash (-) character.
+        # -Every dash (-) character must be immediately preceded and followed by a letter or number.
+        # -All letters in a container name must be lowercase.
+        # -Queue names must be from 3 through 63 characters long.
+        def valid_queue_name?(name)
           name =~ /^[a-z0-9][a-z0-9\-]{1,}[^-]$/ && name.length < 64
         end
 

--- a/spec/waz/blobs/container_spec.rb
+++ b/spec/waz/blobs/container_spec.rb
@@ -171,5 +171,13 @@ describe "Windows Azure Containers interface API" do
   it "should raise an exception when container name is longer than 63" do
     lambda { WAZ::Blobs::Container.create('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')  }.should raise_error(WAZ::Storage::InvalidParameterValue)
   end
+  
+  it "should raise an exception when container name include dollar but isn't root" do
+    lambda { WAZ::Blobs::Container.create('$roots')  }.should raise_error(WAZ::Storage::InvalidParameterValue)
+  end
+  
+  it "should not raise an exception when container name is '$root'" do
+    lambda { WAZ::Blobs::Container.create('$root')  }.should_not raise_error(WAZ::Storage::InvalidParameterValue)
+  end
 
 end


### PR DESCRIPTION
Azure Blob Storage allows us to create and manipulate the [root container](http://msdn.microsoft.com/en-us/library/windowsazure/ee395424.aspx).  This is can be very handy. 

Currently WAZ::Blob has no problem finding and querying the root container (addressed with the name `$root`) however it errs on `Container.create` as the validation helper doesn't permit special characters

To accommodate this, I split the `valid_name` helper into `valid_container_name` and `valid_queue_name`  and update all references.  The previous rules still hold with the one exception for containers called `$root`.

Tests to validate this are included
